### PR TITLE
Update documentation and defaults

### DIFF
--- a/custom/conf/app.example.ini
+++ b/custom/conf/app.example.ini
@@ -968,7 +968,7 @@ ROUTER = console
 ;;
 ;; List of file extensions for which lines should be wrapped in the Monaco editor
 ;; Separate extensions with a comma. To line wrap files without an extension, just put a comma
-;LINE_WRAP_EXTENSIONS = .txt,.md,.markdown,.mdown,.mkd,
+;LINE_WRAP_EXTENSIONS = .txt,.md,.markdown,.mdown,.mkd,livemd,
 ;;
 ;; Valid file modes that have a preview API associated with them, such as api/v1/markdown
 ;; Separate the values by commas. The preview tab in edit mode won't be displayed if the file extension doesn't match

--- a/docs/content/doc/advanced/config-cheat-sheet.en-us.md
+++ b/docs/content/doc/advanced/config-cheat-sheet.en-us.md
@@ -276,6 +276,8 @@ The following configuration set `Content-Type: application/vnd.android.package-a
 - `CUSTOM_URL_SCHEMES`: Use a comma separated list (ftp,git,svn) to indicate additional
   URL hyperlinks to be rendered in Markdown. URLs beginning in http and https are
   always displayed
+- `FILE_EXTENSIONS`: **.md,.markdown,.mdown,.mkd,.livemd**: List of file extensions that should be rendered/edited as
+  Markdown. Seperate the extensions with a comma. To render files without any extension as markdown, just put a comma.
 - `ENABLE_MATH`: **true**: Enables detection of `\(...\)`, `\[...\]`, `$...$` and `$$...$$` blocks as math blocks.
 
 ## Server (`server`)

--- a/modules/setting/repository.go
+++ b/modules/setting/repository.go
@@ -168,7 +168,7 @@ var (
 			LineWrapExtensions   []string
 			PreviewableFileModes []string
 		}{
-			LineWrapExtensions:   strings.Split(".txt,.md,.markdown,.mdown,.mkd,", ","),
+			LineWrapExtensions:   strings.Split(".txt,.md,.markdown,.mdown,.mkd,.livemd,", ","),
 			PreviewableFileModes: []string{"markdown"},
 		},
 


### PR DESCRIPTION
Merge this to fix [your pull request](https://github.com/go-gitea/gitea/pull/22730). Adds the paragraph of documentation that @delvh asked for, as well as changing the default setting for the `LINE_WRAP_EXTENSIONS` setting that you edited the documentation for.